### PR TITLE
Use official docker containers for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 _site
 .sass-cache
 .jekyll-metadata
-_site
+.jekyll-cache
+.vscode
+vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby RUBY_VERSION
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "3.6.3"
+gem "jekyll", "4.2.2"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima"
@@ -22,7 +22,8 @@ gem "minima"
 # group :jekyll_plugins do
 #   gem "jekyll-github-metadata", "~> 1.0"
 # end
+gem "webrick"
 gem "jekyll-paginate"
 gem "classifier-reborn"
-gem "octopress"
-gem "gsl"
+gem "kramdown-parser-gfm"
+# gem "gsl"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,81 +1,90 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    classifier-reborn (2.0.4)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    classifier-reborn (2.3.0)
       fast-stemmer (~> 1.0)
+      matrix (~> 0.4)
     colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
     fast-stemmer (1.0.2)
-    ffi (1.11.1)
+    ffi (1.17.1-x86_64-linux-musl)
     forwardable-extended (2.6.0)
-    gsl (2.1.0.3)
-    jekyll (3.6.3)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.2.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
-      jekyll-sass-converter (~> 1.0)
-      jekyll-watch (~> 1.1)
-      kramdown (~> 1.14)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (~> 2.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (~> 0.3.3)
+      mercenary (~> 0.4.0)
       pathutil (~> 0.9)
-      rouge (>= 1.7, < 3)
+      rouge (~> 3.0)
       safe_yaml (~> 1.0)
+      terminal-table (~> 2.0)
+    jekyll-feed (0.17.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-paginate (1.1.0)
-    jekyll-sass-converter (1.5.2)
-      sass (~> 3.4)
-    jekyll-watch (1.5.1)
+    jekyll-sass-converter (2.2.0)
+      sassc (> 2.0.1, < 3.0)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (1.17.0)
-    liquid (4.0.3)
-    listen (3.2.0)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    mercenary (0.3.6)
-    minima (2.0.0)
-    octopress (3.0.11)
-      jekyll (>= 2.0)
-      mercenary (~> 0.3.2)
-      octopress-deploy
-      octopress-escape-code (~> 2.0)
-      octopress-hooks (~> 2.0)
-      redcarpet (~> 3.0)
-      titlecase
-    octopress-deploy (1.3.0)
-      colorator
-    octopress-escape-code (2.1.1)
-      jekyll (~> 3.0)
-    octopress-hooks (2.6.2)
-      jekyll (>= 2.0)
+    matrix (0.4.2)
+    mercenary (0.4.0)
+    minima (2.5.2)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-feed (~> 0.9)
+      jekyll-seo-tag (~> 2.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (4.0.6)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
+    public_suffix (6.0.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
       ffi (~> 1.0)
-    redcarpet (3.5.1)
-    rouge (2.2.1)
+    rexml (3.4.0)
+    rouge (3.30.0)
     safe_yaml (1.0.5)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    titlecase (0.1.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    terminal-table (2.0.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    unicode-display_width (1.8.0)
+    webrick (1.9.1)
 
 PLATFORMS
-  ruby
+  x86_64-linux-musl
 
 DEPENDENCIES
   classifier-reborn
-  gsl
-  jekyll (= 3.6.3)
+  jekyll (= 4.2.2)
   jekyll-paginate
+  kramdown-parser-gfm
   minima
-  octopress
+  webrick
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 3.1.1p18
 
 BUNDLED WITH
-   1.17.3
+   2.3.25

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,21 @@
+JEKYLL_VERSION=${JEKYLL_VERSION:-4}
+
 watch:
-  jekyll serve --watch --draft --port 4001
+	docker run \
+	--rm \
+	--volume="${PWD}:/srv/jekyll:Z" \
+	-p 4000:4000 \
+	--volume="${PWD}/vendor/bundle:/usr/local/bundle:Z" \
+	"jekyll/jekyll:${JEKYLL_VERSION}" \
+	jekyll serve
 
 build:
-	JEKYLL_ENV=production jekyll build --lsi
+	docker run \
+	--rm \
+	--volume="${PWD}:/srv/jekyll:Z" \
+	--volume="${PWD}/vendor/bundle:/usr/local/bundle:Z" \
+	"jekyll/jekyll:${JEKYLL_VERSION}" \
+	jekyll build
 
 deploy:
 	surge -p _site -d craigbeck.io
@@ -14,7 +27,7 @@ clean:
 	rm -rf _site
 
 check:
-	jekyll doctor
+	docker run --rm --volume="$PWD:/srv/jekyll:Z" -p 4000:4000 --volume="$PWD/vendor/bundle:/usr/local/bundle:Z" jekyll/jekyll:$JEKYLL_VERSION jekyll doctor
 
 linkpost:
 	bundle exec octopress new post "${title}" --template linkpost

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,10 @@
-JEKYLL_VERSION=${JEKYLL_VERSION:-4}
-
-watch:
-	docker run \
-	--rm \
-	--volume="${PWD}:/srv/jekyll:Z" \
-	-p 4000:4000 \
-	--volume="${PWD}/vendor/bundle:/usr/local/bundle:Z" \
-	"jekyll/jekyll:${JEKYLL_VERSION}" \
-	jekyll serve
+# JEKYLL_VERSION=${JEKYLL_VERSION:-4}
 
 build:
-	docker run \
-	--rm \
-	--volume="${PWD}:/srv/jekyll:Z" \
-	--volume="${PWD}/vendor/bundle:/usr/local/bundle:Z" \
-	"jekyll/jekyll:${JEKYLL_VERSION}" \
-	jekyll build
+	docker run --rm --volume="$${PWD}:/srv/jekyll:Z" --volume="$${PWD}/vendor/bundle:/usr/local/bundle:Z" "jekyll/jekyll:4" jekyll build
+
+watch:
+	docker run --rm --volume="$${PWD}:/srv/jekyll:Z" -p 4000:4000 --volume="$${PWD}/vendor/bundle:/usr/local/bundle:Z" "jekyll/jekyll:4" jekyll serve
 
 deploy:
 	surge -p _site -d craigbeck.io

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # JEKYLL_VERSION=${JEKYLL_VERSION:-4}
 
 build:
-	docker run --rm --volume="$${PWD}:/srv/jekyll:Z" --volume="$${PWD}/vendor/bundle:/usr/local/bundle:Z" "jekyll/jekyll:4" jekyll build
+	docker run --rm --volume="$${PWD}:/srv/jekyll:Z" --volume="$${PWD}/vendor/bundle:/usr/local/bundle:Z" jekyll/jekyll:4 jekyll build --incremental
 
 watch:
-	docker run --rm --volume="$${PWD}:/srv/jekyll:Z" -p 4000:4000 --volume="$${PWD}/vendor/bundle:/usr/local/bundle:Z" "jekyll/jekyll:4" jekyll serve
+	docker run --rm --volume="$${PWD}:/srv/jekyll:Z" -p 4000:4000 --volume="$${PWD}/vendor/bundle:/usr/local/bundle:Z" jekyll/jekyll:4 jekyll serve
 
 deploy:
 	surge -p _site -d craigbeck.io
@@ -16,7 +16,5 @@ clean:
 	rm -rf _site
 
 check:
-	docker run --rm --volume="$PWD:/srv/jekyll:Z" -p 4000:4000 --volume="$PWD/vendor/bundle:/usr/local/bundle:Z" jekyll/jekyll:$JEKYLL_VERSION jekyll doctor
+	docker run --rm --volume="$${PWD}:/srv/jekyll:Z" -p 4000:4000 --volume="$${PWD}/vendor/bundle:/usr/local/bundle:Z" jekyll/jekyll:4 jekyll doctor
 
-linkpost:
-	bundle exec octopress new post "${title}" --template linkpost

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,8 @@
 # Use of `relative_permalinks` ensures post links from the index work properly.
 # relative_permalinks: true
 permalink:           pretty
+# permalink config
+# permalink:          /:year/:month/:day/:slug/
 
 # Setup
 title:               craigbeck.io
@@ -11,8 +13,6 @@ description:         ''
 url:                 http://craigbeck.io
 paginate:            5
 
-# permalink config
-permalink:          /:year/:month/:day/:slug/
 
 # About/contact
 author:
@@ -25,7 +25,7 @@ author:
 version:             1.0.0
 
 # require gems for build
-gems:
+plugins:
   - jekyll-paginate
   - classifier-reborn
 

--- a/_posts/2017-12-22-electronics-tutorials.markdown
+++ b/_posts/2017-12-22-electronics-tutorials.markdown
@@ -1,0 +1,16 @@
+---
+layout: post
+title: "Electronics Tutorials"
+date: 2017-12-22T22:02:08-08:00
+linkhref: http://www.electronics-tutorials.ws
+categories:
+  - electronics
+---
+
+
+[{{ page.title }}]({{ page.linkhref }})
+
+A super useful site with lots of basic informaion on circuits and
+electronic components -- resistors, transistors, logic, power and lots
+in between!
+


### PR DESCRIPTION
Old ruby setup was broken on new machines -- no pre-built binaries and not buildable locally on intel or M machines available. Tried updating to newer ruby and Jekyll but still had issues. Switch to using official Jekyll docker images solves and ensures build if portable across both personal machines without chore of local setup.